### PR TITLE
Fix HTML validation errors

### DIFF
--- a/jssdk.html
+++ b/jssdk.html
@@ -32,7 +32,7 @@
                         <h1>JavaScript SDK</h1>
                         <p>When running the examples you will be asked to sign in with a Circuit sandbox account.</p>
                         <a href="https://circuitsandbox.net/sdk" target="_blank" class="btn btn-default">API Documentation</a>
-                        <a href="https://github.com/circuit/circuit-sdk" target="_blank" class="btn btn-default">Github</a><br><br>
+                        <a href="https://github.com/circuit/circuit-sdk" target="_blank" class="btn btn-default">GitHub</a><br><br>
                         <p>Example to logon and fetch conversations:</p>
                         <pre class="prettyprint">
 // Create the client with the client_id (aka app key), scope and optionally a redirect_uri
@@ -61,7 +61,7 @@ client.logon()
 
                 <div class="row" id="plunker">
                     <div class="col-lg-12">
-                        <h3 id="jsbin">Plunker examples</h3>
+                        <h3>Plunker examples</h3>
                         <p>Short examples demonstrating one or more particular APIs. You can view the source, or fork your own plunker. A sandbox account is required to run the live examples. JS Bin examples use OAuth 2.0.</p>
 
                         <table class="table table-condensed">
@@ -98,9 +98,9 @@ client.logon()
                 </div>
 
 
-                <div class="row" id="jsbin">
+                <div class="row">
                     <div class="col-lg-12">
-                        <h3 id="jsbin">JS Bin examples</h3>
+                        <h3>JS Bin examples</h3>
                         <p>Short examples demonstrating one or more particular APIs. You can view the source, or clone your own JS Bin using the link at the top right of the live example. A sandbox account is required to run the live examples. JS Bin examples use OAuth 2.0.</p>
 
                         <table class="table table-condensed">
@@ -209,12 +209,11 @@ client.logon()
                 </div>
 
 
-                <div class="row" id="github">
-
+                <div class="row">
 
                     <div class="col-lg-12">
-                        <h3 id="github">Github examples</h3>
-                        <p>The source code of the examples below are on <a href="https://github.com/circuit/circuit-sdk/tree/master/examples/js/" target="_blank">github</a> and are hosted on <a href="https://rawgit.com/circuit/circuit-sdk/master/examples/js/index.html" target="_blank">rawgit</a>.</p>
+                        <h3>GitHub examples</h3>
+                        <p>The source code of the examples below are on <a href="https://github.com/circuit/circuit-sdk/tree/master/examples/js/" target="_blank">GitHub</a> and are hosted on <a href="https://rawgit.com/circuit/circuit-sdk/master/examples/js/index.html" target="_blank">rawgit</a>.</p>
                         <br>
                     </div>
                     <div class="col-md-4">
@@ -340,7 +339,7 @@ client.logon()
                             <div class="panel-body">
                                 <h5><i class="fa fa-fw fa-check"></i>Share HTML5 Canvas</h5>
                                 <p>This example shows a schematic in a HTML5 canvas and allows drawing on top of it and shares the combined image in the call.
-                                The application can use the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/captureStream" tagert="_blank">HTMLCanvasElement.captureStream</a> API available in Chrome and Firefox to capture a stream from a canvas.
+                                The application can use the new <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/captureStream" target="_blank">HTMLCanvasElement.captureStream</a> API available in Chrome and Firefox to capture a stream from a canvas.
                                 Note that Chrome has an issue with compression which causes WebRTC to reduce the resolution, or not even show the drawing.
                                 Use <a href="https://www.mozilla.org/en-US/firefox/new/">FireFox</a> in the meantime.</p>
                                 <a href="https://rawgit.com/circuit/circuit-sdk/master/examples/js/canvas.html" target="_blank" class="btn btn-default">Live example</a>

--- a/nodejs.html
+++ b/nodejs.html
@@ -14,7 +14,7 @@
         if (window.location.host == 'circuit.github.io' && window.location.protocol != 'https:') {
           window.location.protocol = 'https:';
         }
-    </script
+    </script>
 </head>
 <body>
 

--- a/rest.html
+++ b/rest.html
@@ -14,7 +14,7 @@
         if (window.location.host == 'circuit.github.io' && window.location.protocol != 'https:') {
           window.location.protocol = 'https:';
         }
-    </script
+    </script>
 </head>
 <body>
 

--- a/webcomponents.html
+++ b/webcomponents.html
@@ -16,11 +16,6 @@
       window.location.protocol = 'https:';
     }
   </script>
-  <style>
-    xmp {
-      margin: -32px 0px;
-    }
-  </style>
 </head>
 
 <body>
@@ -40,7 +35,7 @@
             <p>Enhance your website with Circuit features such as making video calls without any code. Just include the
               desired web component module and the Circuit JS SDK and use the element.</p>
 
-              <a href="https://github.com/circuit/circuit-web-components/" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/github-beta-brightgreen.svg?style=flat" style="max-width:100%;"></a>
+              <a href="https://github.com/circuit/circuit-web-components/" target="_blank" rel="nofollow"><img src="https://img.shields.io/badge/github-beta-brightgreen.svg?style=flat" alt="beta" style="max-width:100%;"></a>
               <a href="https://www.npmjs.com/package/@unify/circuit-web-components" target="_blank" rel="nofollow"><img src="https://camo.githubusercontent.com/9e9e962e3dd15ea5ab11b5f1a15a4c15f0b15c49/68747470733a2f2f696d672e736869656c64732e696f2f6e706d2f762f40756e6966792f636972637569742d7765622d636f6d706f6e656e74732e7376673f7374796c653d666c6174" alt="NPM Version" data-canonical-src="https://img.shields.io/npm/v/@unify/circuit-web-components.svg?style=flat" style="max-width:100%;"></a>
               <br><br>
               <a href="https://github.com/circuit/circuit-web-components/tree/master/docs" target="_blank" class="btn btn-default">Documentation</a>
@@ -48,27 +43,26 @@
 
             <p>Example <code>circuit-call-button</code>:</p>
             <pre class="prettyprint">
-              <xmp>
-<html>
-  <head>
-    <script type="module" src="//unpkg.com/@unify/circuit-web-components/circuit-call-button.js" defer></script>
-    <script src="//unpkg.com/circuit-sdk" async></script>
-    <style>
-      /* Hide button until defined to prevent flash rendering */
-      circuit-call-button:not(:defined) {
+&lt;html&gt;
+&lt;head&gt;
+    &lt;script type="module" src="//unpkg.com/@unify/circuit-web-components/circuit-call-button.js" defer&gt;&lt;/script&gt;
+    &lt;script src="//unpkg.com/circuit-sdk" async&gt;&lt;/script&gt;
+    &lt;style&gt;
+    /* Hide button until defined to prevent flash rendering */
+    circuit-call-button:not(:defined) {
         opacity: 0;
-      }
-      circuit-call-button[inprogress] {
+    }
+    circuit-call-button[inprogress] {
         background: firebrick;
-      }
-    </style>
-  </head>
-  <body>
-    <circuit-call-button
-      clientId="f76ea1b2789946c9b88b008c682c132a"
-      target="helpdesk@company.com">Call Helpdesk</circuit-call-button>
-  </body>
-</html></xmp>
+    }
+    &lt;/style&gt;
+&lt;/head&gt;
+&lt;body&gt;
+    &lt;circuit-call-button
+    clientId="f76ea1b2789946c9b88b008c682c132a"
+    target="helpdesk@company.com"&gt;Call Helpdesk&lt;/circuit-call-button&gt;
+&lt;/body&gt;
+&lt;/html&gt;
             </pre>
 
           </div>


### PR DESCRIPTION
Validate files with https://validator.w3.org/ and https://www.freeformatter.com/html-validator.html.

Some of the findings:

- Using obsolete <xmp> tag. This is the larger change.
- <script tag not closed
- Missing mandatory alt= for image
- Duplicate id= in files